### PR TITLE
macros to generate getters and setters

### DIFF
--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -12,6 +12,7 @@ module Utilities
 
     # Functions
     export createTimeStampedFolder, p_yearly2monthly
+    export @decl_setters, @decl_getters, @decl_getsetters
 
     # list of types 
 
@@ -43,4 +44,26 @@ module Utilities
         "" 
     end
  
+    function setter(field, type) 
+        name = Symbol(String(field) * "!")
+        :($(esc(name))(x::$type, value) = (x.$field = value))
+    end
+
+    function getter(field, type) 
+        :($(esc(field))(x::$type) = x.$field)
+    end
+
+    macro decl_setters(type, fields...)
+        Expr(:Block, [setter(f, type) for f in fields])
+    end
+
+    macro decl_getters(type, fields...)
+        Expr(:Block, [setter(f, type) for f in fields])
+    end
+
+    macro decl_getsetters(type, fields...)
+        Expr(:block, 
+             [[setter(f, type) for f in fields] ;
+              [getter(f, type) for f in fields]]...)
+    end
 end 


### PR DESCRIPTION
I got tired of having to declare all these accessor functions, so I added a few simple macros to Utilities to automate the process. 
Use like this:
```Julia
@decl_getsetters Bla x y
@decl_setters Bla z
```
This will produce:
```Julia
x(var::Bla) = var.x
y(var::Bla) = var.y
x!(var::Bla, val) = (var.x = val)
y!(var::Bla, val) = (var.y = val)
z!(var::Bla, val) = (var.z = val)
```